### PR TITLE
rename go module

### DIFF
--- a/binary_parser.go
+++ b/binary_parser.go
@@ -50,7 +50,7 @@ func newBinaryParser(r io.ReadSeeker) (*binaryParser, error) {
 	}
 
 	// numObjectsMax is arbitrary. Please fix.
-	// TODO(github.com/groob/plist/issues/28)
+	// TODO(github.com/micromdm/plist/issues/28)
 	if bp.NumObjects > numObjectsMax {
 		return nil, fmt.Errorf("plist: offset size larger than expected %d", numObjectsMax)
 	}

--- a/example_unmarshaler_test.go
+++ b/example_unmarshaler_test.go
@@ -3,7 +3,7 @@ package plist_test
 import (
 	"fmt"
 
-	"github.com/groob/plist"
+	"github.com/micromdm/plist"
 )
 
 const data = `<?xml version="1.0" encoding="UTF-8"?>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/groob/plist
+module github.com/micromdm/plist
 
 go 1.14


### PR DESCRIPTION
Now that we've moved from groob/plist to micromdm/plist, lets rename the actual module.

I'm not sure the implications to the folks who use the old module name. While the GitHub redirect is probably transparent I'd guess this change would make code break. I'm unsure if Go's version handling in dependent `go.mod`'s would properly protect against that. Maybe?