### PR TITLE
ignore comments in XML plist files (fixes #44)

### DIFF
--- a/testdata/xml/comment.plist
+++ b/testdata/xml/comment.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- comment -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- comment -->
+<plist version="1.0">
+<!-- comment -->
+<dict>
+    <!-- comment -->
+	<key>key</key>
+    <!-- comment -->
+	<string>val</string>
+    <!-- comment -->
+    <key>key2</key>
+    <array>
+        <!-- comment -->
+        <string>val1</string>
+        <string>val2</string>
+    </array>
+</dict>
+<!-- comment -->
+</plist>

--- a/xml_parser.go
+++ b/xml_parser.go
@@ -17,6 +17,19 @@ type xmlParser struct {
 	*xml.Decoder
 }
 
+func (p *xmlParser) Token() (xml.Token, error) {
+	for {
+		token, err := p.Decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := token.(xml.Comment); ok {
+			continue
+		}
+		return token, nil
+	}
+}
+
 // newXMLParser returns a new xmlParser
 func newXMLParser(r io.Reader) *xmlParser {
 	return &xmlParser{xml.NewDecoder(r)}


### PR DESCRIPTION
Override the default decoder's `Token` function to ignore any comment elements. This also includes a test case.

This fixes #44.